### PR TITLE
Update top players scraper to upload to RDS

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -5,6 +5,3 @@ headless = False
 actId = d929bc38-4ab6-7da4-94f0-ee84f8ac141e
 queue = competitive
 minMatchCount = 30
-bucket = valorant-scraper
-folder = top-players
-filename = top100players

--- a/connectRds.py
+++ b/connectRds.py
@@ -20,19 +20,33 @@ def queryRds(query: str) -> tuple:
             cur = connection.cursor()
             cur.execute(query)
             results = cur.fetchall()
-    except:
-        print('Failed query.')
-    return results
+            
+        return results
+    
+    except Exception as e:
+        print(e)
+
 
 
 def insertRds(statement: str, val: list):
-    with connectRds() as connection:
-        cur = connection.cursor()
-       
         try:
-            cur.executemany(statement, val)
-            connection.commit()
-            print(str(cur.rowcount) + ' rows inserted.')
+            with connectRds() as connection:
+                cur = connection.cursor()
+                cur.executemany(statement, val)
+                connection.commit()
+            print(str(cur.rowcount) + ' records inserted.')
+            
         except Exception as e:
-            print(e) #'Failed insert.'
+            print(e)
+            
+def updateRds(statement: str):
+    try:
+        with connectRds() as connection:
+            cur = connection.cursor()
+            cur.execute(statement)
+            connection.commit()
+        print(str(cur.rowcount) + 'records updated.')
+    except Exception as e:
+        print(e)
+
             


### PR DESCRIPTION
Updated valScraperScript to upload scraped top players to RDS directly instead of uploading to S3 (which then initiates an AWS glue job). Also include query to update all old entries "latest_data" field to be set to 0 / False. 

config.ini updated to remove S3 bucket path.
connectRds.py updated to include "updateRds" method
valScraperLibs.py updated to include "act_id" in output

Other: moved config variables to modules instead of script. Removed unused libraries.